### PR TITLE
feat:react-screenshots 增加鼠标双击确认截图

### DIFF
--- a/packages/react-screenshots/src/components/Screenshots/ScreenshotsViewer.js
+++ b/packages/react-screenshots/src/components/Screenshots/ScreenshotsViewer.js
@@ -113,11 +113,13 @@ export default class ScreenshotsViewer extends PureComponent {
     this.draw()
     window.addEventListener('mousemove', this.onMousemove)
     window.addEventListener('mouseup', this.onMouseup)
+    window.addEventListener('dblclick', this.onDblClick)
   }
 
   componentWillUnmount () {
     window.removeEventListener('mousemove', this.onMousemove)
     window.removeEventListener('mouseup', this.onMouseup)
+    window.removeEventListener('dblclick', this.onDblClick)
   }
 
   componentDidUpdate () {
@@ -214,6 +216,12 @@ export default class ScreenshotsViewer extends PureComponent {
         action.mouseup(e, this.actionArgs)
       }
     }
+  }
+
+  onDblClick = (e) => {
+    const { actions } = this.props
+    const Action = actions.find(t => t.type !== 'divider' && t.key.title === '确定').key
+    this.onAction(Action)
   }
 
   handlePointInRecord = e => {


### PR DESCRIPTION
因为个人习惯了用QQ截图时直接双击能存剪切板，所以增加了鼠标双击确认，请看下是否有必要合并