### PR TITLE
fix: 修复当前应用设置始终置顶后,截图不能捕捉到应用窗口

### DIFF
--- a/packages/electron-screenshots/src/screenshots.ts
+++ b/packages/electron-screenshots/src/screenshots.ts
@@ -216,7 +216,7 @@ export default class Screenshots extends Events {
       width: display.width,
       height: display.height
     })
-
+    this.$win.setAlwaysOnTop(true)
     this.$win.show()
   }
 


### PR DESCRIPTION
问题说明：
如果在当前`electron`应用调用了`setAlwaysOnTop(true)`方法，会导致盖在生成的截图窗口上层，需要在`createWindow()`方法内部重新将截图窗口置顶

