### PR TITLE
feat: add afterSave event

### DIFF
--- a/packages/electron-screenshots/README.md
+++ b/packages/electron-screenshots/README.md
@@ -41,6 +41,11 @@ app.whenReady().then(() => {
   screenshots.on("save", (e, buffer, bounds) => {
     console.log("capture", buffer, bounds);
   });
+  // 保存后的回调事件
+  screenshots.on("afterSave", (e, buffer, bounds, isSaved) => {
+    console.log("capture", buffer, bounds);
+    console.log("isSaved", isSaved) // 是否保存成功
+  });
   debug({ showDevTools: true, devToolsMode: "undocked" });
 });
 

--- a/packages/electron-screenshots/README.md
+++ b/packages/electron-screenshots/README.md
@@ -180,13 +180,14 @@ class Event {
 }
 ```
 
-| 名称          | 说明                                                        | 回调参数                                                        |
-| ------------- | ----------------------------------------------------------- | --------------------------------------------------------------- |
-| ok            | 截图确认事件                                                | `(event: Event, buffer: Buffer, data: ScreenshotsData) => void` |
-| cancel        | 截图取消事件                                                | `(event: Event) => void`                                        |
-| save          | 截图保存事件                                                | `(event: Event, buffer: Buffer, data: ScreenshotsData) => void` |
-| windowCreated | 截图窗口被创建后触发                                        | `($win: BrowserWindow) => void`                                 |
-| windowClosed  | 截图窗口被关闭后触发，对`BrowserWindow` `closed` 事件的转发 | `($win: BrowserWindow) => void`                                 |
+| 名称          | 说明                                                        | 回调参数                                                                          |
+| ------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| ok            | 截图确认事件                                                | `(event: Event, buffer: Buffer, data: ScreenshotsData) => void`                   |
+| cancel        | 截图取消事件                                                | `(event: Event) => void`                                                          |
+| save          | 截图保存事件                                                | `(event: Event, buffer: Buffer, data: ScreenshotsData) => void`                   |
+| afterSave     | 截图保存（取消保存）后的事件                                | `(event: Event, buffer: Buffer, data: ScreenshotsData, isSaved: boolean) => void` |
+| windowCreated | 截图窗口被创建后触发                                        | `($win: BrowserWindow) => void`                                                   |
+| windowClosed  | 截图窗口被关闭后触发，对`BrowserWindow` `closed` 事件的转发 | `($win: BrowserWindow) => void`                                                   |
 
 ### 说明
 

--- a/packages/electron-screenshots/src/screenshots.ts
+++ b/packages/electron-screenshots/src/screenshots.ts
@@ -386,14 +386,18 @@ export default class Screenshots extends Events {
         });
 
         if (!this.$win) {
+          this.emit('afterSave', new Event(), buffer, data, false); // isSaved = false
           return;
         }
+
         this.$win.setAlwaysOnTop(true);
         if (canceled || !filePath) {
+          this.emit('afterSave', new Event(), buffer, data, false); // isSaved = false
           return;
         }
 
         await fs.writeFile(filePath, buffer);
+        this.emit('afterSave', new Event(), buffer, data, true); // isSaved = true
         this.endCapture();
       },
     );


### PR DESCRIPTION
增加了 `afterSave` 事件:
```ts
  // 保存后的回调事件
  screenshots.on("afterSave", (e, buffer, bounds, isSaved) => {
    console.log("capture", buffer, bounds);
    console.log("isSaved", isSaved) // 是否保存成功
  });
```