### PR TITLE
fix: convert display center point to screen coordinates for monitor 

### DIFF
--- a/packages/electron-screenshots/src/index.ts
+++ b/packages/electron-screenshots/src/index.ts
@@ -7,6 +7,7 @@ import {
   dialog,
   ipcMain,
   nativeImage,
+  screen,
 } from 'electron';
 import Events from 'events';
 import fs from 'fs-extra';
@@ -242,10 +243,14 @@ export default class Screenshots extends Events {
 
     try {
       const { Monitor } = await import('node-screenshots');
-      const monitor = Monitor.fromPoint(
-        display.x + display.width / 2,
-        display.y + display.height / 2,
-      );
+      let point = {
+        x: display.x + display.width / 2,
+        y: display.y + display.height / 2,
+      };
+      if (process.platform === 'win32') {
+        point = screen.screenToDipPoint(null, point);
+      }
+      const monitor = Monitor.fromPoint(point);
       this.logger(
         'SCREENSHOTS:capture Monitor.fromPoint arguments %o',
         display,


### PR DESCRIPTION
**问题描述：**packages/electron-screenshots/src/index.ts  下的capture方法，会计算display的中心坐标，这是一个像素坐标，在windows环境下值会受到屏幕缩放比例的影响。而Monitor.fromPoint()方法需要接收的是真实的物理坐标，两者的坐标系并不匹配。

**修复方法：**本次PR利用electorn中screen模块的dipToScreenRect方法，将像素坐标转换为物理坐标，以正确定位屏幕